### PR TITLE
Allow simple passing file as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 - Python 3.8
 
-To use, just run `python screamterpreter.py` in the project directory.
+To use, just run `screamterpreter.py` or `screamterpreter.py [file to load]` in the project directory. Is using files as an arg, it must be passed as a relative path.
 Pre-written files must be stored in a folder named 'screams', in the same directory as the main .py file. File names are case-sensitive. I've included a 'Hello World' program to help you get a feel for how programs are written.
 
 ## Instruction Set
@@ -20,7 +20,6 @@ Instructions are seperated by a space or newline.
  OWIE    | Jump back to the matching `OW` if the cell at the pointer is nonzero 
 
 ## Planned Features
-- Loading files as arg (i.e `$screamterpret foobar.PAIN`)
 - Python IDLE-like UI (except terminal-based, because I still need to learn forms.)
 
 ## Contribution

--- a/screamcode
+++ b/screamcode
@@ -1,2 +1,0 @@
-#!/bin/bash
-python screamterpreter.py

--- a/screamterpreter.py
+++ b/screamterpreter.py
@@ -17,7 +17,6 @@ def getch():
 
 
 def interpret(scream):
-    print("---------------------------------------\nOutput:\n")
     pointerMap = {0:0}
     pointerLocation = 0
     step = 0
@@ -76,6 +75,7 @@ def writeDirect():
             lines.append(screamcode)
 
     screamcode = ' '.join(lines)
+    print("---------------------------------------\nOutput:\n")
     interpret(' '.join(lines))
 
 def loadFile():
@@ -89,10 +89,20 @@ def loadFile():
     try:
         with open(loadTarget, encoding="utf-8") as file:
             lines = [l.rstrip('\n') for l in file]
+        print("---------------------------------------\nOutput:\n")
         interpret(' '.join(lines))
     except FileNotFoundError:
         print("No such file in screams directory.")
 
+try:
+    fileDir = os.getcwd()
+    loadTarget = fileDir + '/' + sys.argv[1]
+    with open(loadTarget, encoding="utf-8") as file:
+        lines = [l.rstrip('\n') for l in file]
+    interpret(' '.join(lines))
+    quit()
+except IndexError:
+    pass
 
 print('\n\nWritten by Baguette (https://hbaguette.neocities.org)')
 print('#####################################################\n## [L] Load File  [D] Interpret Directly  [Q] Quit ##\n#####################################################')


### PR DESCRIPTION
- Allows the user to pass a file as an argument when running the program (i.e `screamterpreter.py foobar.PAIN`), as long as the path given as the arg is relative to the user's current directory.
- Does not support absolute paths.